### PR TITLE
Fix macro to be 5.12, not 5.18

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include <QScreen>
 #include <QQmlApplicationEngine>
 #include <QtQml/QQmlContext>
-#if QT_VERSION >= 0x51200
+#if QT_VERSION >= 0x50C00
 #include <QWebEngineUrlScheme>
 #endif
 #include <QWebEngineUrlRequestJob>
@@ -27,7 +27,7 @@ int main(int argc, char *argv[]) {
     auto endUrl = QUrl::fromUserInput(parser.positionalArguments()[1]);
 
     auto scheme = endUrl.scheme().toStdString();
-#if QT_VERSION >= 0x51200
+#if QT_VERSION >= 0x50C00
     QWebEngineUrlScheme::registerScheme(QWebEngineUrlScheme(scheme.c_str()));
 #endif
     SchemeHandler handler(endUrl.toString());


### PR DESCRIPTION
qt5.12 prints a warning, this fixes it.

I'm merging feature-xal to ng and include your helpful work.